### PR TITLE
refactor(util): rename exported object and remove useless error

### DIFF
--- a/src/configurations/util.ts
+++ b/src/configurations/util.ts
@@ -2,8 +2,6 @@ import { PackageGenerationError } from '../types';
 export const STRING_PARAMETER_SYMBOL = ':';
 
 export const PACKAGE_GENERATION_ERROR: PackageGenerationError = {
-  'Parameter not found in message':
-    'The following parameters were not found in the message:',
   'Command argument': "Argument :argument isn't valid for this command",
   'Command value': 'No value passed for argument :argument',
   'Configuration file missing': "File :path doesn't exist",

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,3 +2,4 @@ export * as commandLine from './commandLine';
 export * as packageCreation from './packageCreation';
 export * as configFile from './configFile';
 export * as folder from './folder';
+export * as util from './util';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as configurations from './configurations';
 import * as helpers from './helpers';
-const packageGenerator = { helpers, configurations };
-export default packageGenerator;
+const monorepoPackageGenerator = { helpers, configurations };
+export default monorepoPackageGenerator;
 export type {
   CommandOptions,
   PackageCreationConfiguration,

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -4,7 +4,6 @@ export type PackageGenerationErrorType =
   | 'Configuration file missing'
   | 'Sample file folder'
   | 'Package type'
-  | 'Package already exists'
-  | 'Parameter not found in message';
+  | 'Package already exists';
 
 export type PackageGenerationError = Record<PackageGenerationErrorType, string>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,11 +22,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arondilbe/package-generator@workspace:.":
+"@arondilbe/monorepo-package-generator@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@arondilbe/package-generator@workspace:."
+  resolution: "@arondilbe/monorepo-package-generator@workspace:."
   dependencies:
-    "@arondilbe/string-parameters-parser": "npm:^1.0.0"
+    "@arondilbe/string-parameters-parser": "npm:^1.0.1"
     "@types/inquirer": "npm:^9.0.7"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.27"
@@ -48,12 +48,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@arondilbe/string-parameters-parser@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@arondilbe/string-parameters-parser@npm:1.0.0"
+"@arondilbe/string-parameters-parser@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@arondilbe/string-parameters-parser@npm:1.0.1"
   dependencies:
     chalk: "npm:^4.1.2"
-  checksum: 10/26f0aeaac73e8322257304d2ec33987fcee0b54ca4fc0b57556d43bd75d0d97ec17ea71e8dd5fbf96385d13bf4158b122d1a9cb1f5046f50cfb6e4fc54353c81
+  checksum: 10/bccdfd61f271053c34e35e0fb266dabeb847a59d0e300674573581b605fa73b7bf2a6e2585fc23fbc850ec4d3956760627d0971134ed3691232be1840f370a66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rename the main exported object to have the new name of the pacakge (#2) and remove argument not found package as it's extracted into another package (#3)

#2, #3