### PR TITLE
feat(files): copy packake type related files

### DIFF
--- a/sampleFilesExample/util/index.ts
+++ b/sampleFilesExample/util/index.ts
@@ -1,0 +1,1 @@
+// Will replace the common one

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -10,36 +10,35 @@ export const doesFileOrFolderExist = (filePath: string): boolean =>
   existsSync(resolve(filePath));
 
 /**
- * Copy all the commonFiles
- * @param {string} destinationPath The folder where the common files should be copied
- * @param {string} sourcePath The folder from which the common files should be copied
- * @param {string[]} packageTypeFolders An array of package type folders name to be ignored during the copy
+ * Copy files from source to destination
+ * @param {string} destinationPath The folder where the files should be copied
+ * @param {string} sourcePath The folder from which the files should be copied
+ * @param {string[]} foldersToIgnore An array of folder names to be ignored during the copy
  */
-export const copyCommonFiles = (
+export const copyFiles = (
   destinationPath: string,
   sourcePath: string,
-  packageTypeFolders?: string[],
+  foldersToIgnore?: string[],
 ): void => {
   cpSync(sourcePath, destinationPath, {
     recursive: true,
-    filter:
-      packageTypeFolders && packageTypeFolders.length
-        ? (folder: string) => {
-            for (
-              let typeIndex = 0;
-              typeIndex < packageTypeFolders.length;
-              typeIndex += 1
+    filter: foldersToIgnore
+      ? (folder: string) => {
+          for (
+            let typeIndex = 0;
+            typeIndex < foldersToIgnore.length;
+            typeIndex += 1
+          ) {
+            if (
+              // Adding the source path to be sure to only skip the package types folder an not some
+              // folders/files with the same name in other folders
+              folder.includes(join(sourcePath, foldersToIgnore[typeIndex]))
             ) {
-              if (
-                // Adding the source path to be sure to only skip the package types folder an not some
-                // folders/files with the same name in other folders
-                folder.includes(join(sourcePath, packageTypeFolders[typeIndex]))
-              ) {
-                return false;
-              }
+              return false;
             }
-            return true;
           }
-        : undefined,
+          return true;
+        }
+      : undefined,
   });
 };

--- a/src/helpers/packageGeneration.ts
+++ b/src/helpers/packageGeneration.ts
@@ -5,7 +5,7 @@ import { SUCCESS_MESSAGE, WARNING_MESSAGE } from '../configurations/util.js';
 import { PackageGenerationInformation } from '../types/packageGeneration.js';
 
 import { getPackageGenerationConfigurationFromFile } from './config.js';
-import { copyCommonFiles, doesFileOrFolderExist } from './file.js';
+import { copyFiles, doesFileOrFolderExist } from './file.js';
 import {
   getListOfNonExistingPackageTypes,
   getNonExistingPackageTypeFolders,
@@ -121,11 +121,18 @@ export const generatePackage = (options: {
 
   createPackageFolder(packageCreationPath);
 
-  copyCommonFiles(
+  copyFiles(
     packageCreationPath,
     sampleFilesPath,
     packageTypes ? Object.values(packageTypes) : undefined,
   );
+
+  if (type) {
+    copyFiles(
+      packageCreationPath,
+      join(sampleFilesFolderPath, packageTypes?.[type] as string),
+    );
+  }
 
   displayMessage('success', SUCCESS_MESSAGE, {
     parameters: { path: packageCreationPath },


### PR DESCRIPTION
Copy all files from the package type folder (only if type is specified). If files from the specific folder have the same name and are at the same place than the common ones, they will replace them

#47